### PR TITLE
Fix: Show Language's tagline on each execution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ pub struct Vars {
 
 fn main() -> std::io::Result<()> {
     let mut filename = String::new();
+    println!("Welcome to the Ram stack-based programming language.");
     if env::args().nth(1).is_none() == true {
-        println!("Welcome to the Ram stack-based programming language.");
         println!("Please enter a filename: ");
         io::stdin().read_line(&mut filename)?;
         filename = filename.trim().to_string();


### PR DESCRIPTION
The line
```rust
println!("Welcome to the Ram stack-based programming language.");
```
was in if statement.
Moved it above so that it shows this statement everytime.